### PR TITLE
merging segmented kaldi wrapper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,5 @@
 FROM brandeisllc/aapb-pua-kaldi:v1
 # which has python3.7
-
-LABEL maintainer="Angus L'Herrou <piraka@brandeis.edu>"
-
-# hipstas/kaldi-pop-up-archive:v1 uses Ubuntu 16.10 Yakkety, which is dead, so no apt repositories.
-# Have to tell apt to use Ubuntu 18.04 Bionic's apt repositories, since that's the oldest LTS with
-# Python 3.6. This is terrible!
-RUN cp /etc/apt/sources.list /etc/apt/sources.list.old && \
-    sed -i -e s/yakkety/bionic/g /etc/apt/sources.list
-
 # may not want to do apt-get update if there are dependencies of
 # the Kaldi image that rely on older versions of apt packages
 RUN apt-get update && \

--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ import subprocess
 from typing import Dict, Sequence, Tuple, List, Union
 import argparse
 import tempfile
+import bisect
 
 from clams import ClamsApp, Restifier
 from mmif import Mmif, View, Annotation, Document, AnnotationTypes, DocumentTypes, Text
@@ -21,6 +22,8 @@ TEXT_DOCUMENT_PREFIX = 'td'
 TIME_FRAME_PREFIX = 'tf'
 ALIGNMENT_PREFIX = 'a'
 TRANSCRIPT_DIR = "output"
+SILENCE_GAP_LEN = 1 # seconds to insert between segments when trimming
+
 
 __ALL__ = [
     "WRAPPED_IMAGE",
@@ -32,6 +35,12 @@ __ALL__ = [
     "Kaldi",
     "kaldi"
 ]
+
+TIME_UNITS = {
+    'milliseconds': 1000,
+    'seconds': 1
+}
+
 
 def kaldi_exp_dir(kaldi_root):
     return os.path.join(kaldi_root, 'egs', 'american-archive-kaldi', 'sample_experiment')
@@ -70,15 +79,25 @@ class Kaldi(ClamsApp):
         # get AudioDocuments with locations
         docs = [document for document in mmif_obj.documents
                 if document.at_type == DocumentTypes.AudioDocument.value and len(document.location) > 0]
+        files = {}
+        tf_src_view = {}
+        trimming_tmpdir = tempfile.TemporaryDirectory()
 
-        files = {doc.id: doc.location for doc in docs}
-
-        # key them by location basenames
-        docs_dict: Dict[str, Document] = {os.path.splitext(os.path.basename(doc.location))[0]: doc for doc in docs}
-        assert len(docs) == len(docs_dict), 'no duplicate filenames'
-        # TODO (angus-lherrou @ 2020-10-03): allow duplicate basenames for files originally from different folders
-        #  by renaming files more descriptively
-
+        for doc in docs:
+            segment_views = [view for view in mmif_obj.get_views_for_document(doc.id) if AnnotationTypes.TimeFrame.value in view.metadata.contains]
+            if len(segment_views) > 1:
+                # TODO (krim @ 11/30/20): we might want to actually handle this situation; e.g. for evaluating multiple segmenter
+                raise ValueError('got multiple segmentation views for a document with TimeFrames')
+            elif len(segment_views) == 1:
+                view = segment_views[0]
+                segments = [(int(ann.properties['start']), int(ann.properties['end'])) for ann in view.get_annotations(AnnotationTypes.TimeFrame, frameType='speech')]
+                unit = view.metadata.contains[AnnotationTypes.TimeFrame.value]['unit']
+                trimmed_fname = os.path.join(trimming_tmpdir.name, doc.id + '.wav')
+                slice_and_merge_audio(trimmed_fname, doc.location, segments, unit=unit, silence_gap=SILENCE_GAP_LEN)
+                files[doc.id] = trimmed_fname
+                tf_src_view[doc.id] = view.id
+            else:
+                files[doc.id] = doc.location
 
         transcript_tmpdir = None
         if run_kaldi:
@@ -86,7 +105,6 @@ class Kaldi(ClamsApp):
             transcripts = transcript_tmpdir.name
         else:
             transcripts = TRANSCRIPT_DIR
-
 
         # get Kaldi's output
         for transcript_fname in os.listdir(transcripts): # files names after the ID of the AudioDocs
@@ -96,29 +114,106 @@ class Kaldi(ClamsApp):
                 # convert transcript to MMIF view
                 view: View = mmif_obj.new_view()
                 self.stamp_view(view, audiodoc_id)
-                # join tokens
                 whitespace = ' '
-                raw_text = whitespace.join([token['word'] for token in transcript['words']])
-                # make annotations
-                textdoc = self.create_td(raw_text, 0)
-                view.add_document(textdoc)
-                align_1 = self.create_align(mmif_obj.get_document_by_id(audiodoc_id), textdoc, 0)
-                view.add_annotation(align_1)
                 position = 0
-                for index, word_obj in enumerate(transcript['words']):
-                    raw_token = word_obj['word']
-                    start = position
-                    end = start + len(raw_token)
-                    position += len(raw_token) + len(whitespace)
-                    tf = self.create_tf(word_obj['time'], word_obj['duration'], index)
-                    raw_token = self.create_token(word_obj['word'], index, start, end, f'{view.id}:{textdoc.id}')
-                    align = self.create_align(tf, raw_token, index+1)  # counting one for TextDoc-AudioDoc alignment
-                    view.add_annotation(raw_token)
-                    view.add_annotation(tf)
-                    view.add_annotation(align)
+                if audiodoc_id in tf_src_view:
+                    td_idx = 0
+                    alignment_idx = 0
+                    # the view with time frame
+                    view_wtf = mmif_obj.get_view_by_id(tf_src_view[audiodoc_id])
+                    segments = {ann.id: (int(ann.properties['start']), int(ann.properties['end'])) for ann in view_wtf.get_annotations(AnnotationTypes.TimeFrame, frameType='speech')}
+
+                    # what the below is doing is basically create 'zippable' lists
+                    # (segment_ids, ostarts, oends, nstarts, nends)
+                    # that are all aligned to the order of speech segments found in the view_wtf
+                    segment_ids = sorted(segments.keys()) # assuming segments are sorted by the start points
+                    # original start points and end points
+                    ostarts = sorted([s for s, _ in segments.values()])
+                    oends = sorted([e for _, e in segments.values()])
+                    # new time offsets in the "trimmed" audio
+                    nstarts = []
+                    nends = []
+                    for i in range(len(ostarts)):
+                        if i == 0:
+                            nstarts.append(0)
+                        else:
+                            nstarts.append(nends[i-1]+SILENCE_GAP_LEN)
+                        nends.append(oends[i] - ostarts[i] + nstarts[i])
+
+                    # and put the cursor to the first speech segment
+                    cur_segment = 0
+                    # start with an empty text doc to provide text doc id to token annotations
+                    raw_text = ""
+                    textdoc = self.create_td(raw_text, td_idx)
+                    td_idx += 1
+                    for index, word_obj in enumerate(transcript['words']):
+                        raw_token = word_obj['word']
+                        # this time point is bound to the "trimmed" audio stream
+                        time_start = word_obj['time']
+                        # figure out in which n-th segment this token was
+                        segment_num = bisect.bisect(nstarts, time_start) - 1
+
+                        # and count characters
+                        char_start = position
+                        char_end = char_start + len(raw_token)
+                        position += len(raw_token) + len(whitespace)
+                        # next, figure out this token is kaldi's recognition of silence gap we used to buffer two segments in "trimmed" audio
+                        # if so, ignore this token
+                        if nends[segment_num] < time_start:
+                            continue
+                        # when moved on to the next speech segment
+                        if segment_num - 1 == cur_segment:
+                            # inject collected tokens into the text doc and finalize it
+                            del raw_text[-1]
+                            textdoc.properties.text_language = 'en'
+                            textdoc.properties.text_value = raw_text
+                            view.add_document(textdoc)
+                            td_tf_alignment = self.create_align(segment_ids[cur_segment], textdoc, alignment_idx)
+                            alignment_idx += 1
+                            view.add_annotation(td_tf_alignment)
+
+                            # reset stuff and start a new text doc
+                            position = 0
+                            cur_segment += 1
+                            raw_text = ""
+                            textdoc = self.create_td(raw_text, td_idx)
+                            td_idx += 1
+
+                        # regardless of speech segment, process individual tokens
+                        token = self.create_token(raw_token, index, char_start, char_end, f'{view.id}:{textdoc.id}')
+                        # convert the time stamp to the original audio
+                        original_time_start = time_start + ostarts[segment_num] - nstarts[segment_num]
+                        # TODO (krim @ 11/30/20): what happens when a kaldi recognized token spreads over to a "silence" zone?
+                        tf = self.create_tf(original_time_start, word_obj['duration'], index)
+                        tk_tf_alignment = self.create_align(tf, token, alignment_idx)
+                        alignment_idx += 1
+                        view.add_annotation(token)
+                        view.add_annotation(tf)
+                        view.add_annotation(tk_tf_alignment)
+                        raw_text += raw_token + whitespace
+                else:
+                    # join tokens
+                    raw_text = whitespace.join([token['word'] for token in transcript['words']])
+                    # make annotations
+                    textdoc = self.create_td(raw_text, 0)
+                    view.add_document(textdoc)
+                    align_1 = self.create_align(mmif_obj.get_document_by_id(audiodoc_id), textdoc, 0)
+                    view.add_annotation(align_1)
+                    for index, word_obj in enumerate(transcript['words']):
+                        raw_token = word_obj['word']
+                        start = position
+                        end = start + len(raw_token)
+                        position += len(raw_token) + len(whitespace)
+                        tf = self.create_tf(word_obj['time'], word_obj['duration'], index)
+                        token = self.create_token(word_obj['word'], index, start, end, f'{view.id}:{textdoc.id}')
+                        align = self.create_align(tf, token, index+1)  # counting one for TextDoc-AudioDoc alignment
+                        view.add_annotation(token)
+                        view.add_annotation(tf)
+                        view.add_annotation(align)
 
         if transcript_tmpdir:
             transcript_tmpdir.cleanup()
+        trimming_tmpdir.cleanup()
         return mmif_obj.serialize(pretty=pretty)
 
     @staticmethod
@@ -170,6 +265,35 @@ class Kaldi(ClamsApp):
         view.new_contain(Uri.TOKEN)
         view.new_contain(AnnotationTypes.TimeFrame.value, {'unit': 'milliseconds', 'document': tf_source_id})
         view.new_contain(AnnotationTypes.Alignment.value)
+
+
+def slice_and_merge_audio(out_fname: str,
+                          in_fname: str,
+                          indexed_speech_segments: Sequence[Tuple[int, int]],
+                          unit='milliseconds',
+                          silence_gap=1,
+                          dryrun=False):
+    # this gap will be inserted after each segment when merging back to a single audio file
+    original_audio = ffmpeg.input(in_fname)
+    silence = ffmpeg.input('anullsrc', f='lavfi')
+    to_concat = []
+    silences = silence.filter_multi_output('asplit')
+    for i, (start, end) in enumerate(indexed_speech_segments):
+        start = start / TIME_UNITS[unit]
+        end = end / TIME_UNITS[unit]
+        silence = silences[i]
+        gap = silence.filter('atrim', duration=silence_gap)
+        to_concat.append(original_audio.filter('atrim', start=start, end=end))
+        to_concat.append(gap)
+    print(to_concat)
+    del to_concat[-1] # fence posting
+    cmd = ffmpeg.concat(*to_concat, v=0, a=1)
+    cmd = cmd.output(out_fname)
+    # for debugging
+    if dryrun:
+        print(' '.join(cmd.compile()))
+    else:
+        cmd.run(overwrite_output=True)
 
 
 def kaldi(files: Dict[str, str]) -> tempfile.TemporaryDirectory:

--- a/app.py
+++ b/app.py
@@ -232,8 +232,8 @@ class Kaldi(ClamsApp):
         token.at_type = Uri.TOKEN
         token.id = TOKEN_PREFIX + str(index + 1)
         token.add_property('word', word)
-        token.add_property('start', str(start))
-        token.add_property('end', str(end))
+        token.add_property('start', start)
+        token.add_property('end', end)
         token.add_property('document', source_doc_id)
         return token
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-clams-python~=0.1.5
+clams-python~=0.2.1
 lapps~=0.0.2
 ffmpeg-python==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 clams-python~=0.1.5
 lapps~=0.0.2
+ffmpeg-python==0.2.0


### PR DESCRIPTION
This implementation of PUA kaldi wrapper looks for `TimeFrame` annotations with `frameType=speech` properties and use them if they are found. Later to be updated with a proper *optional* input type implementation. 